### PR TITLE
Support buffer_size on build_output_stream for coreaudio

### DIFF
--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -713,7 +713,6 @@ impl EventLoop {
         if let BufferSize::Fixed(size) = &buffer_size {
             let size = *size as u32;
             audio_unit.set_property(kAudioDevicePropertyBufferFrameSize, scope, element, Some(&size))?;
-            println!("setting buffer size {}", size);
         }
 
         // Determine the future ID of the stream.

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -41,6 +41,7 @@ use self::coreaudio::sys::{
     AudioStreamBasicDescription,
     AudioValueRange,
     kAudioDevicePropertyAvailableNominalSampleRates,
+    kAudioDevicePropertyBufferFrameSize,
     kAudioDevicePropertyDeviceNameCFString,
     kAudioDevicePropertyNominalSampleRate,
     kAudioObjectPropertyScopeInput,
@@ -698,8 +699,6 @@ impl EventLoop {
         buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
-        *buffer_size = BufferSize::Default; // afaik there's no way to get the buffer size beforehand and it can change
-
         let mut audio_unit = audio_unit_from_device(device, false)?;
 
         // The scope and element for working with a device's output stream.
@@ -709,6 +708,13 @@ impl EventLoop {
         // Set the stream in interleaved mode.
         let asbd = asbd_from_format(format);
         audio_unit.set_property(kAudioUnitProperty_StreamFormat, scope, element, Some(&asbd))?;
+
+        // Set the buffer size
+        if let BufferSize::Fixed(size) = &buffer_size {
+            let size = *size as u32;
+            audio_unit.set_property(kAudioDevicePropertyBufferFrameSize, scope, element, Some(&size))?;
+            println!("setting buffer size {}", size);
+        }
 
         // Determine the future ID of the stream.
         let stream_id = self.next_stream_id();


### PR DESCRIPTION
This PR continues work on the `buffer-size-request` branch and [PR](https://github.com/tomaka/cpal/pull/239) by adding support for setting the buffer size on coreaudio for output stream. Seems to work with some basic testing.

It currently doesn't update the mutable reference to the final buffer size. 

My main reference for this was: https://developer.apple.com/library/archive/technotes/tn2321/_index.html#//apple_ref/doc/uid/DTS40013499-CH1-THE_I_O_BUFFER_SIZE

A similar technique should work for input stream. Also it should be possible to retrieve the buffer size using `kAudioDevicePropertyBufferFrameSize`.